### PR TITLE
GET all comments for a particular expense report - I adjusted the rou…

### DIFF
--- a/controllers/comment/commentController.js
+++ b/controllers/comment/commentController.js
@@ -15,7 +15,7 @@ const replyModel = require('../../models/reply');
  */
 exports.getAll = [
 	async function(req, res, next) {
-		let expense_id = req.params.expense_id;
+		let expense_id = req.query.expense_id;
 		try{
 			var options = {
 		    	uri: `https://my-json-server.typicode.com/airondev/json-server/expenses/${expense_id}/comments`, //this will be replaced with uri to comments api service

--- a/routes/comments.js
+++ b/routes/comments.js
@@ -7,8 +7,13 @@ var commentController = require("../controllers/comment/commentController");
 // this should have been changed to commentController, i dont want to change it at this point
 var projectsController = require("../controllers/comment/commentController");
 
-// GET: route to get all comments for a particular expenses - airon
-router.get("/expenses/:expense_id/comments", commentController.getAll);
+/* 
+* GET: route to get all comments for a particular expense report
+* expense_id should be passed as a query string 
+* example: /comments?expense_id=1
+* this adjustment is intended to accommodate the change in route pattern by a team member
+*/
+router.get("/", commentController.getAll);
 
 //POST - User can post comments by Name and Email (i.e '/comment')
 router.post("/", projectsController.postCommentByEmail);


### PR DESCRIPTION
**ADJUSTMENT**
#GET all comments for a particular expense report 
- I adjusted the route to accommodate the change in route pattern by a team member. 
- Based on this development,  expense_id must be passed a query string eg: /comments?expense_id=1

