### PR TITLE
feat: update upvote endpoint to use comments api

### DIFF
--- a/controllers/comment/commentController.js
+++ b/controllers/comment/commentController.js
@@ -1,70 +1,68 @@
-const Request = require("request");
-const stringify = require('json-stringify-safe');
+const request = require("request");
+const stringify = require("json-stringify-safe");
 
+let rp = require("request-promise");
 
-let rp = require('request-promise');
+const commentModel = require("../../models/Comment");
+const userModel = require("../../models/User");
+const replyModel = require("../../models/reply");
 
-const commentModel = require('../../models/Comment');
-const userModel = require('../../models/User');
-const replyModel = require('../../models/reply');
-
+// The url to the comments API.
+const commentsAPIUrl = "https://fgn-comments-service.herokuapp.com/";
 
 /**
  * export.method = req, res function
  * get all comments on a particular expense report from comments microservice
  */
 exports.getAll = [
-	async function(req, res, next) {
-		let expense_id = req.query.expense_id;
-		try{
-			var options = {
-		    	uri: `https://my-json-server.typicode.com/airondev/json-server/expenses/${expense_id}/comments`, //this will be replaced with uri to comments api service
-			    headers: {
-			        'User-Agent': 'Request-Promise'
-			    },
-		    	json: true // Automatically parses the JSON string in the response
-			};
-		 
-			const comments = await rp(options)
-		    	.then(function (comments) {
-		        return comments;
-		    })
-		    .catch(function (err) {
-        		// API call failed...
-        		res.json({
-   					status: false,
-   					error: err.name,
-   					message: err.message
-   				});
-   			});
+  async function (req, res, next) {
+    let expense_id = req.query.expense_id;
+    try {
+      var options = {
+        uri: `https://my-json-server.typicode.com/airondev/json-server/expenses/${expense_id}/comments`, //this will be replaced with uri to comments api service
+        headers: {
+          "User-Agent": "Request-Promise",
+        },
+        json: true, // Automatically parses the JSON string in the response
+      };
 
-   		if(comments){
-   			res.json({
-   				status: true,
-   				comments: comments
-   			});
-   		}
-   		
-		 }catch(err){
-		 		console.log(err.message);
-		 }
+      const comments = await rp(options)
+        .then(function (comments) {
+          return comments;
+        })
+        .catch(function (err) {
+          // API call failed...
+          res.json({
+            status: false,
+            error: err.name,
+            message: err.message,
+          });
+        });
 
-	}
+      if (comments) {
+        res.json({
+          status: true,
+          comments: comments,
+        });
+      }
+    } catch (err) {
+      console.log(err.message);
+    }
+  },
 ];
 
 // comments should be added here - thanks
-exports.postCommentByEmail =  async(req, res) =>{
-    const {comment, name, email}  = req.body;
-    try{
-    const newComment = new commentModel({comment, name, email});
-    await newComment.save()
-    .then(comment => {
-      userModel.findOne({email: req.body.email})
-      .then((user) =>{
-          console.log(user)
-        user.comments = user.comments.push(comment)
-        user.save()
-        .then(comment =>{
+exports.postCommentByEmail = async (req, res) => {
+  const { comment, name, email } = req.body;
+  try {
+    const newComment = new commentModel({ comment, name, email });
+    await newComment
+      .save()
+      .then((comment) => {
+        userModel.findOne({ email: req.body.email }).then((user) => {
+          console.log(user);
+          user.comments = user.comments.push(comment);
+          user.save().then((comment) => {
             res.status(200).json({
               status: "Successful",
               data: comment,
@@ -86,51 +84,55 @@ exports.postCommentByEmail =  async(req, res) =>{
   }
 };
 
+// Adds one upvote to comment
 exports.upvoteComment = (req, res) => {
-  commentModel
-    .findById(req.params.id)
-    .then((comment) => {
-      const updatedComment = { ...comment, upVotes: (comment.upVotes += 1) };
-      return res.json({
-        status: "Success",
-        data: updatedComment,
-      });
-    })
-    .catch((err) => {
-      return res.status(400).json({
-        status: "Failed",
-        message: err.message,
-        data: null,
-      });
-    });
+  const options = {
+    url: `${commentsAPIUrl}reports/comment/vote/${req.id}`,
+    method: "PATCH",
+    headers: {
+      Accept: "application/json",
+      "Accept-Charset": "utf-8",
+    },
+    json: true,
+    body: req.body,
+  };
+
+  request(options, function (err, _, body) {
+    if (err) {
+      res.status(400).json({ status: "Failed", message: err, data: null });
+    } else {
+      res.status(200).json(body);
+    }
+  });
 };
 
-exports.postReply = async (req, res) =>{
-    const {reply, email} = req.body;
-    try{
-    const replyDetails =  new replyModel({reply, email })
+exports.postReply = async (req, res) => {
+  const { reply, email } = req.body;
+  try {
+    const replyDetails = new replyModel({ reply, email });
     replyDetails.noOfReplies += 1;
-    await replyDetails.save()
-    .then((reply) =>{
-        console.log(reply)
-         commentModel.findById({_id: req.params.id})
-    .then((comment) => {
-        console.log(comment.replies, reply.id)
+    await replyDetails.save().then((reply) => {
+      console.log(reply);
+      commentModel.findById({ _id: req.params.id }).then((comment) => {
+        console.log(comment.replies, reply.id);
         comment.replies.unshift(reply);
-        comment.save()
-        .then( details => res.json({ status: 'Success', msg: 'Reply posted', data: details}))
-        })
-    })
-        
-    }
-    catch(e) {
-        res.status(400).json({status: 'Failed', message: `${e.message}`, data: null})
-    }
+        comment
+          .save()
+          .then((details) =>
+            res.json({ status: "Success", msg: "Reply posted", data: details })
+          );
+      });
+    });
+  } catch (e) {
+    res
+      .status(400)
+      .json({ status: "Failed", message: `${e.message}`, data: null });
+  }
 };
 
 //return all comments and replies
-exports.getAllCommentsAndReplies = (req, res) =>{
-    /* const url = 'http://localhost:4000/comment/unflagged';
+exports.getAllCommentsAndReplies = (req, res) => {
+  /* const url = 'http://localhost:4000/comment/unflagged';
     Request.get(url, (error, response, body) => {
     if(error) {
         return  res.status(400).json({status: 'Failed', message: err.message, data: null});
@@ -138,10 +140,21 @@ exports.getAllCommentsAndReplies = (req, res) =>{
     console.dir(JSON.parse(body));
     return res.json({ status: 'Success', msg: 'All comments and replies', data: JSON.parse(body)})
 }); */
-     commentModel.find()
-        .then(comments => res.json({ status: 'Success', msg: 'All comments and replies', data: comments}))
-        .catch(err => res.status(400).json({status: 'Failed', message: err.message, data: null}));
-    };
+  commentModel
+    .find()
+    .then((comments) =>
+      res.json({
+        status: "Success",
+        msg: "All comments and replies",
+        data: comments,
+      })
+    )
+    .catch((err) =>
+      res
+        .status(400)
+        .json({ status: "Failed", message: err.message, data: null })
+    );
+};
 
 //This retrieves only unflagged comments
 exports.hideFlaggedComments = (req, res) => {
@@ -178,26 +191,44 @@ exports.hideFlaggedComments = (req, res) => {
     );
 };
 
-exports.flagComment = async (req, res) =>{
-    try{
-        const flagComment = await commentModel.findById({_id: req.params.id});
-        if(!flagComment) return res.status(404).json({status: 'Failed', message: "No comment found", data: null });
-        flagComment.flag = true;
-        flagComment.numOfFlags +=1;
-        flagComment.save();
-        res.json({status: 'Success', message: "Comment Flagged", data: flagComment})
-    }
-    catch(e) {
-        res.status(400).json({status: 'Failed', message: `${e.message}`, data: null})
-    }
+exports.flagComment = async (req, res) => {
+  try {
+    const flagComment = await commentModel.findById({ _id: req.params.id });
+    if (!flagComment)
+      return res
+        .status(404)
+        .json({ status: "Failed", message: "No comment found", data: null });
+    flagComment.flag = true;
+    flagComment.numOfFlags += 1;
+    flagComment.save();
+    res.json({
+      status: "Success",
+      message: "Comment Flagged",
+      data: flagComment,
+    });
+  } catch (e) {
+    res
+      .status(400)
+      .json({ status: "Failed", message: `${e.message}`, data: null });
+  }
 };
-exports.deleteComment = async (req, res) =>{
-    try{
-        const deleteComment = await commentModel.findByIdAndDelete({_id: req.params.id});
-        if(!deleteComment) return res.status(404).json({status: 'Failed', message: "Failed to delete comment: comment not found", data: null});
-        res.status(200).json({status: 'Sucess', message: 'Comment deleted', data: null})
-    }
-    catch(e){
-        res.status(400).json({status: 'Failed', message: `${e.message}`, data: null});
-    }
-}
+exports.deleteComment = async (req, res) => {
+  try {
+    const deleteComment = await commentModel.findByIdAndDelete({
+      _id: req.params.id,
+    });
+    if (!deleteComment)
+      return res.status(404).json({
+        status: "Failed",
+        message: "Failed to delete comment: comment not found",
+        data: null,
+      });
+    res
+      .status(200)
+      .json({ status: "Sucess", message: "Comment deleted", data: null });
+  } catch (e) {
+    res
+      .status(400)
+      .json({ status: "Failed", message: `${e.message}`, data: null });
+  }
+};

--- a/controllers/comment/commentController.js
+++ b/controllers/comment/commentController.js
@@ -101,7 +101,7 @@ exports.upvoteComment = (req, res) => {
     if (err) {
       res.status(400).json({ status: "Failed", message: err, data: null });
     } else {
-      res.status(200).json(body);
+      res.status(202).json(body);
     }
   });
 };

--- a/routes/comments.js
+++ b/routes/comments.js
@@ -7,19 +7,19 @@ var commentController = require("../controllers/comment/commentController");
 // this should have been changed to commentController, i dont want to change it at this point
 var projectsController = require("../controllers/comment/commentController");
 
-/* 
-* GET: route to get all comments for a particular expense report
-* expense_id should be passed as a query string 
-* example: /comments?expense_id=1
-* this adjustment is intended to accommodate the change in route pattern by a team member
-*/
+/*
+ * GET: route to get all comments for a particular expense report
+ * expense_id should be passed as a query string
+ * example: /comments?expense_id=1
+ * this adjustment is intended to accommodate the change in route pattern by a team member
+ */
 router.get("/", commentController.getAll);
 
 //POST - User can post comments by Name and Email (i.e '/comment')
 router.post("/", projectsController.postCommentByEmail);
 
-// PUT - Upvote comment (i.e '/comment/:id/upvotes')
-router.put("/:id/upvotes", projectsController.upvoteComment);
+// PATCH - Add upvote to comment (i.e '/comment/:id/upvotes')
+router.patch("/:id/upvotes", projectsController.upvoteComment);
 
 //POST replies - user can post reply to a comment
 router.post("/:id/replies", projectsController.postReply);


### PR DESCRIPTION
**What does this PR do?**
Creates a method in the comment controller that will send upvote using comment id to comment api and return the updated data as its response.

**description of Task to be completed?**
Same as above.

**How should this be manually tested?**
1. Run command: `npm run startDev`.
2. Using postman, send PATCH request: `http://localhost:4000/comments/5eeb42dc56459a3014a527e8/upvotes`

**Any background context you want to provide?**
None.

**What is the link to the user story on clubhouse if available?**
[#51536](https://app.clubhouse.io/startng/story/51536/create-a-method-in-the-comment-controller-that-will-send-upvote-using-comment-id-to-comment-api-and-return-the-updated-data)

**Questions:**
The current setup is a bit hard to test fully because the comments API is still being built, I get a response back but I think the response is currently a placeholder so I will probably have to test it again once the endpoint for sending upvotes is fully implemented by the comments API team. But the current code should work regardless.