### PR TITLE
fix: req object should call params for id

### DIFF
--- a/controllers/comment/commentController.js
+++ b/controllers/comment/commentController.js
@@ -88,14 +88,14 @@ exports.postCommentByEmail = async (req, res) => {
 // Adds one upvote to comment
 exports.upvoteComment = (req, res) => {
   const options = {
-    url: `${commentsAPIUrl}reports/comment/vote/${req.id}`,
+    url: `${commentsAPIUrl}reports/comment/vote/${req.params.id}`,
     method: "PATCH",
     headers: {
       Accept: "application/json",
       "Accept-Charset": "utf-8",
     },
     json: true,
-    body: req.body,
+    body: { vote_type: "upvote" },
   };
 
   request(options, function (err, _, body) {


### PR DESCRIPTION
**What does this PR do?**
Update a method in the comment controller that will send upvote using comment id to comment api and return the updated data as its response.

**description of Task to be completed?**
1. `req.id` would return undefined. Instead `req.params.id` should be used. 
2. The internal implementation of the request body should send a upvote vote type to the comments api.

**How should this be manually tested?**
Once it has been deployed to the server it can be tested by going to this endpoint with an id of 1 using a PATCH method.
```
https://expenseng.com//comments/1/upvotes
```

**Any background context you want to provide?**
None

**What is the link to the user story on clubhouse if available?**
[#51536](https://app.clubhouse.io/startng/story/51536/create-a-method-in-the-comment-controller-that-will-send-upvote-using-comment-id-to-comment-api-and-return-the-updated-data)

**Questions:**
None