### PR TITLE
add route for getting a single expense

### DIFF
--- a/controllers/web/expenseController.js
+++ b/controllers/web/expenseController.js
@@ -148,3 +148,29 @@ exports.getExpensesByYearAndMonth = async (req, res) => {
       .json({ status: "Failed", message: err.message, data: null });
   }
 };
+
+exports.getSingleExpense = async (req, res) => {
+  try {
+    const expense = await Expenses.findById(req.params.id).populate(
+      "mdas companies"
+    );
+    if (!expense)
+      return res.status(404).json({
+        status: "failed",
+        message: "Expense not found",
+        data: null,
+      });
+
+    res.status(200).json({
+      status: "success",
+      message: "Expense Details",
+      data: { expense },
+    });
+  } catch (err) {
+    res.status(400).json({
+      status: "failed",
+      message: err.message,
+      data: null,
+    });
+  }
+};

--- a/routes/web.js
+++ b/routes/web.js
@@ -85,7 +85,7 @@ router.get("/mda/heads", mdaController.getAllHeads);
 
 router.get("/expenses", expenseController.getExpenses);
 
-//router.get("/expense/:id", expenseController.getSingleExpense);
+router.get("/expenses/:id", expenseController.getSingleExpense);
 router.post("/expenses/create", expenseController.createExpenses);
 
 //index route redirecting to the main FE home page


### PR DESCRIPTION
**Before submitting your PR for review**

- Run `npm run lint` to find errors in code syntax/format
- Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- Ensure you fix any linting errors displayed after running any of the above commands

**What does this PR do?**

Add a controller for getting a single expense

**description of Task to be completed?**

From the design there's a need to get the details for a single expense. Hence, the need for this route. This controller gets a requested expense along with its associated Company and Ministry

**How should this be manually tested?**

By making GET request to ` ${base_url}/expenses/:id` using POSTMAN

**Any background context you want to provide?**

N/A

**What is the link to the user story on clubhouse if available?**
N/A

**Questions:**

N/A